### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -45,9 +45,10 @@ jobs:
         working-directory: docs
         run: JEKYLL_ENV=production bundle exec jekyll build
 
-      - name: deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          SINGLE_COMMIT: true
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs/_site
+          path: 'docs/_site'
+
+      - name: deploy website
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR fixes the issue of doc-gen making files that are too big to store in Git without LFS. Instead of maintaining a `gh-pages` branch, we push an artifact directly to GitHub's backend. To enable this, a maintainer will need to go to Settings > Code and Automation > Pages and change "Deploy from a branch" to "GitHub Actions":
![image](https://github.com/YaelDillies/LeanCamCombi/assets/50671761/ed8c9fe6-4df1-4ff4-a3f6-ab97354436f2)
Then, once this PR is merged and CI is successfully run, `gh-pages` can be deleted.