### PR TITLE
ExtrProbCombi: Exclude diagonal edges from the Bernoulli random variables of a binomial random graph

### DIFF
--- a/LeanCamCombi/ExtrProbCombi/BinomialRandomGraph.lean
+++ b/LeanCamCombi/ExtrProbCombi/BinomialRandomGraph.lean
@@ -22,47 +22,61 @@ Rényi introduced a closely related but different model. We therefore choose the
 descriptive name.
 -/
 
-open MeasureTheory ProbabilityTheory
-open scoped Finset ENNReal NNReal
+open MeasureTheory ProbabilityTheory SimpleGraph
+open scoped Finset ENNReal NNReal Set.Notation
 
 variable {α Ω : Type*} [MeasurableSpace Ω]
 
 /-- A graph-valued random variable is a `p`-binomial random graph (aka follows the Erdős–Rényi
 model) if its edges are iid `p`-Bernoulli random variables. -/
 abbrev IsBinomialRandomGraph (G : Ω → SimpleGraph α) (p : ℝ≥0) (μ : Measure Ω := by volume_tac) : Prop :=
-  IsBernoulliSeq (fun ω ↦ (G ω).edgeSet) p μ
+  IsBernoulliSeq (fun ω ↦ {e | ¬ e.IsDiag} ↓∩ (G ω).edgeSet) p μ
 
 variable {G : Ω → SimpleGraph α} {H : SimpleGraph α} {p : ℝ≥0} (μ : Measure Ω)
-  (hG : IsBinomialRandomGraph G p μ)
+  (hG : IsBinomialRandomGraph G p μ) {e e₁ e₂ : Sym2 α}
 
 namespace IsBinomialRandomGraph
 include hG
 
 protected nonrec lemma le_one : p ≤ 1 := hG.le_one
 
-protected nonrec lemma iIndepFun : iIndepFun inferInstance (fun e ω ↦ e ∈ (G ω).edgeSet) μ :=
+lemma iIndepFun_mem_edgeSet_not_isDiag :
+    iIndepFun inferInstance (fun (e : {e : Sym2 α // ¬ e.IsDiag}) ω ↦ ↑e ∈ (G ω).edgeSet) μ :=
   hG.iIndepFun
 
-protected nonrec lemma map (e : Sym2 α) :
+lemma iIndepFun_mem_edgeSet : iIndepFun inferInstance (fun e ω ↦ e ∈ (G ω).edgeSet) μ :=
+  sorry
+
+lemma map_mem_edgeSet (he : ¬ e.IsDiag) :
     Measure.map (fun ω ↦ e ∈ (G ω).edgeSet) μ = (PMF.bernoulli' p hG.le_one).toMeasure :=
-  hG.map _
+  hG.map ⟨e, he⟩
 
-protected nonrec lemma aemeasurable (e : Sym2 α) : AEMeasurable (fun ω ↦ e ∈ (G ω).edgeSet) μ :=
-  hG.aemeasurable _
+lemma aemeasurable_mem_edgeSet : AEMeasurable (fun ω ↦ e ∈ (G ω).edgeSet) μ := by
+  by_cases he : e.IsDiag
+  · simp [imp_not_comm.1 (not_isDiag_of_mem_edgeSet _), he]
+  · exact hG.aemeasurable ⟨e, he⟩
 
-protected nonrec lemma nullMeasurableSet (e : Sym2 α) :
-    NullMeasurableSet {ω | e ∈ (G ω).edgeSet} μ := hG.nullMeasurableSet _
+lemma nullMeasurableSet_mem_edgeSet (e : Sym2 α) : NullMeasurableSet {ω | e ∈ (G ω).edgeSet} μ := by
+  by_cases he : e.IsDiag
+  · simp [imp_not_comm.1 (not_isDiag_of_mem_edgeSet _), he]
+  · exact hG.nullMeasurableSet ⟨e, he⟩
 
-protected nonrec lemma identDistrib (d e : Sym2 α) :
-    IdentDistrib (fun ω ↦ d ∈ (G ω).edgeSet) (fun ω ↦ e ∈ (G ω).edgeSet) μ μ :=
-  hG.identDistrib _ _
+lemma identDistrib_mem_edgeSet_mem_edgeSet (he₁ : ¬ e₁.IsDiag) (he₂ : ¬ e₂.IsDiag) :
+    IdentDistrib (fun ω ↦ e₁ ∈ (G ω).edgeSet) (fun ω ↦ e₂ ∈ (G ω).edgeSet) μ μ :=
+  hG.identDistrib ⟨e₁, he₁⟩ ⟨e₂, he₂⟩
 
-lemma meas_edge (e : Sym2 α) : μ {ω | e ∈ (G ω).edgeSet} = p := hG.meas_apply _
+lemma meas_mem_edgeSet (he : ¬ e.IsDiag) : μ {ω | e ∈ (G ω).edgeSet} = p := hG.meas_apply ⟨e, he⟩
 
 protected nonrec lemma meas [IsProbabilityMeasure μ] [Fintype α] [DecidableEq α]
     [DecidableRel H.Adj] :
     μ {ω | G ω = H} =
-      p ^ #H.edgeFinset * (1 - p) ^ (Fintype.card (Sym2 α) - #H.edgeFinset) := by
-  simpa using hG.meas H.edgeFinset
+      p ^ #H.edgeFinset * (1 - p) ^ (Fintype.card {e : Sym2 α // ¬ e.IsDiag} - #H.edgeFinset) := by
+  have := hG.meas
+    (H.edgeFinset.attach.map <| ⟨Set.inclusion fun e he ↦
+      not_isDiag_of_mem_edgeSet _ <| mem_edgeFinset.1 he, Set.inclusion_injective _⟩)
+  simp at this
+  rw [Finset.card_attach, ← Fintype.card_subtype_compl] at this
+  convert this
+  sorry
 
 end IsBinomialRandomGraph


### PR DESCRIPTION
Concretely, no random variable satisfied the previous definition.

Close #16.